### PR TITLE
Check for wp-load file

### DIFF
--- a/src/wp.php
+++ b/src/wp.php
@@ -4,6 +4,11 @@
  * 
  * @author Khaled Hossain
  */
+
+if (defined('ABSPATH') && file_exists( ABSPATH . 'wp-load.php' )) {
+    return;
+}
+
 if (! function_exists('esc_attr')) {
 
     /**


### PR DESCRIPTION
We would like to include this library as a global composer dependency in several of our WP projects, instead of running it from within User Meta Pro. Currently we can't do that because we autoload at the beginning of the WP application stack so the WP functions redefined in this file don't actually exist yet. This update bails if it finds the wp-load.php file, which is basically the very first thing WP runs.